### PR TITLE
Close clients when max clients exceeded

### DIFF
--- a/hittpd.c
+++ b/hittpd.c
@@ -1164,8 +1164,13 @@ main(int argc, char *argv[])
 						accept_client(i, connfd);
 					break;
 				}
-			if (i == MAX_CLIENTS)
+			if (i == MAX_CLIENTS) {
 				printf("too many clients\n");
+				int connfd = accept(listenfd, 0, 0);
+				if (connfd >= 0)
+					close(connfd);
+				continue;
+			}
 			if (i > maxi)
 				maxi = i; /* max index in client[] array */
 			if (--nready <= 0)


### PR DESCRIPTION
After compiling with `-fsanitize=address`, you can see that
hittpd would crash with the following commands:

```bash
ulimit -n 4096; ./hittpd
for i in {1..1024}; do (echo ""; sleep 5) > /dev/tcp/127.0.0.1/80 & done
```

Shoutouts to [c3h2_ctf](https://twitter.com/c3h2_ctf).